### PR TITLE
Do not persist actions/checkout credentials

### DIFF
--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -21,6 +21,8 @@ jobs:
           echo "CI_INITIAL_TIMESTAMP=$(date '+%s')" >> $GITHUB_ENV
       - name: Check out repo        
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Identify the notification channel
         run: |
           echo "CI_SLACK_CHANNEL=$(jq -c -r '.NotificationChannel' .docker/build/config.json)" >> $GITHUB_ENV


### PR DESCRIPTION
As I feared, this branch as it is now removes permission to push hints, snapshot etc.
We are hit by https://github.com/orgs/community/discussions/26694 . From what I understand from that discussion and https://github.com/actions/checkout#checkout-v3, the token used by `actions/checkout` is persisted by default, and if so, then it is impossible to also explicitly use another token at the same time.
This PR fixes that accordingly.
